### PR TITLE
Yarn2 berry ntm experimental

### DIFF
--- a/apps/blog-app/package.json
+++ b/apps/blog-app/package.json
@@ -54,7 +54,7 @@
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "jest-cli": "^26.6.3",
-    "next-transpile-modules": "^7.0.0",
+    "next-transpile-modules": "https://github.com/martpie/next-transpile-modules.git#experimental-module-resolution",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.15",
     "prettier": "^2.3.0",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -51,7 +51,7 @@
     "jest": "^26.6.3",
     "jest-circus": "^26.6.3",
     "jest-cli": "^26.6.3",
-    "next-transpile-modules": "^7.0.0",
+    "next-transpile-modules": "https://github.com/martpie/next-transpile-modules.git#experimental-module-resolution",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.15",
     "prettier": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "typecheck": "yarn workspaces foreach -ptv run typecheck",
     "lint": "yarn workspaces foreach -ptv run lint",
     "check:install": "yarn dlx @yarnpkg/doctor .",
+    "apps:build": "yarn workspaces foreach -ptv --include '*-app' run build",
+    "apps:clean": "yarn workspaces foreach -ptv --include '*-app' run clean",
     "packages:build": "yarn workspaces foreach -ptv --include '@optional-package-scope/*' run build",
     "packages:lint": "yarn workspaces foreach -ptv --include '@optional-package-scope/*' run lint",
     "packages:typecheck": "yarn workspaces foreach -ptv --include '@optional-package-scope/*' run typecheck",

--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -54,7 +54,6 @@
     "typecheck": "tsc -p ./ --noEmit",
     "test": "run-s 'test:*'",
     "test:unit": "echo \"No tests yet\"",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "fix:staged-files": "lint-staged --allow-empty",
     "fix:all-files": "eslint . --ext .ts,.tsx,.js,.jsx --fix"
   }

--- a/packages/foo/package.json
+++ b/packages/foo/package.json
@@ -13,7 +13,9 @@
     "name": "Vanvelthem Sébastien",
     "url": "https://github.com/belgattitude"
   },
-  "main": "./src/index.ts",
+  "source": "src/index.ts",
+  "main": "dist/foo.js",
+  "module": "dist/foo.module.js",
   "devDependencies": {
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
@@ -47,7 +49,7 @@
     "typescript": "^4.2.4"
   },
   "scripts": {
-    "build:noworking:ntm": "microbundle --tsconfig ./tsconfig.build.json --jsx React.createElement --compress",
+    "build": "microbundle --tsconfig ./tsconfig.build.json --jsx React.createElement --compress",
     "build:react17jsx": "microbundle --tsconfig ./tsconfig.build.json --jsx jsx --jsxImportSource react --globals react/jsx-runtime=jsx --compress",
     "clean": "rimraf --no-glob ./dist",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4010,7 +4010,7 @@ __metadata:
     jest-circus: ^26.6.3
     jest-cli: ^26.6.3
     next: ^10.2.0
-    next-transpile-modules: ^7.0.0
+    next-transpile-modules: "https://github.com/martpie/next-transpile-modules.git#experimental-module-resolution"
     npm-run-all: ^4.1.5
     postcss: ^8.2.15
     prettier: ^2.3.0
@@ -10230,13 +10230,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-transpile-modules@npm:^7.0.0":
+"next-transpile-modules@https://github.com/martpie/next-transpile-modules.git#experimental-module-resolution":
   version: 7.0.0
-  resolution: "next-transpile-modules@npm:7.0.0"
+  resolution: "next-transpile-modules@https://github.com/martpie/next-transpile-modules.git#commit=1b187f1039de30f5e644568176ba27a2e530b7ea"
   dependencies:
     enhanced-resolve: ^5.7.0
     escalade: ^3.1.1
-  checksum: e18ab9275d5bc2a7aa60306aeef0d33ee9fc809d16238fb4f8ed4500eb52b650a2298f484aab91222e28db9e8635c2c23eb86a566719702e6df20e912f6834c0
+  checksum: 95837894a8c9e88fc6f6816297fe01a4850c818e7d8e891122167086a7f96e96a6c0d9eec38757024aab542134d259ab34d16b37f09cb808d45722760da19e59
   languageName: node
   linkType: hard
 
@@ -15023,7 +15023,7 @@ resolve@^2.0.0-next.3:
     jest-circus: ^26.6.3
     jest-cli: ^26.6.3
     next: ^10.2.0
-    next-transpile-modules: ^7.0.0
+    next-transpile-modules: "https://github.com/martpie/next-transpile-modules.git#experimental-module-resolution"
     npm-run-all: ^4.1.5
     postcss: ^8.2.15
     prettier: ^2.3.0


### PR DESCRIPTION
Trying out stuff with about @martpie branch experimental-module-resolution

https://github.com/martpie/next-transpile-modules/pull/202#issuecomment-839756682

## Purpose

Shared packages should be publishable, so the main field should point to `dist/index.js` and not the transpiled source folder.

## Test this out

```
yarn install
yarn build:packages  // should work  (will build all packages with microbundle)
yarn apps:build // should work too (will use next-transpile-module to enable monorepo transpilation)
```