### PR TITLE
[Repro] Yarn 3.0.0-rc.2 - YARN_CACHE_FOLDER not working on first time

### DIFF
--- a/apps/blog-app/package.json
+++ b/apps/blog-app/package.json
@@ -64,7 +64,7 @@
     "rimraf": "^3.0.2",
     "tailwindcss": "^2.1.2",
     "ts-jest": "^26.5.6",
-    "typescript": "^4.3.1-rc"
+    "typescript": "4.2.4"
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -65,7 +65,7 @@
     "sass": "^1.32.13",
     "tailwindcss": "^2.1.2",
     "ts-jest": "^26.5.6",
-    "typescript": "^4.3.1-rc"
+    "typescript": "4.2.4"
   },
   "dependencies": {
     "@emotion/react": "^11.4.0",

--- a/packages/core-lib/package.json
+++ b/packages/core-lib/package.json
@@ -44,7 +44,7 @@
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.6",
-    "typescript": "^4.3.1-rc"
+    "typescript": "4.2.4"
   },
   "scripts": {
     "build:noworking:ntm": "microbundle --tsconfig ./tsconfig.build.json --jsx React.createElement --compress",

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^17.0.2",
     "rimraf": "^3.0.2",
     "ts-jest": "^26.5.6",
-    "typescript": "^4.3.1-rc"
+    "typescript": "4.2.4"
   },
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3185,7 +3185,7 @@ __metadata:
     react-dom: ^17.0.2
     rimraf: ^3.0.2
     ts-jest: ^26.5.6
-    typescript: ^4.3.1-rc
+    typescript: 4.2.4
   peerDependencies:
     react: ^16.14.0 || ^17.0.1
     react-dom: ^16.14.0 || ^17.0.1
@@ -3225,7 +3225,7 @@ __metadata:
     react-dom: ^17.0.2
     rimraf: ^3.0.2
     ts-jest: ^26.5.6
-    typescript: ^4.3.1-rc
+    typescript: 4.2.4
   peerDependencies:
     react: ^16.14.0 || ^17.0.1
     react-dom: ^16.14.0 || ^17.0.1
@@ -4072,7 +4072,7 @@ __metadata:
     rimraf: ^3.0.2
     tailwindcss: ^2.1.2
     ts-jest: ^26.5.6
-    typescript: ^4.3.1-rc
+    typescript: 4.2.4
   languageName: unknown
   linkType: soft
 
@@ -14629,7 +14629,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-typescript@^4.1.3:
+"typescript@4.2.4, typescript@^4.1.3":
   version: 4.2.4
   resolution: "typescript@npm:4.2.4"
   bin:
@@ -14639,33 +14639,13 @@ typescript@^4.1.3:
   languageName: node
   linkType: hard
 
-typescript@^4.3.1-rc:
-  version: 4.3.1-rc
-  resolution: "typescript@npm:4.3.1-rc"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: e095fdb2112b1078ba292d8f26ec8f869480fb23509870f530dcace5500984f46041f8369dd368e3ce05277cf0cb8316ac71c6ed896584c22c1f47b4b4b6a05b
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
+"typescript@patch:typescript@4.2.4#~builtin<compat/typescript>, typescript@patch:typescript@^4.1.3#~builtin<compat/typescript>":
   version: 4.2.4
   resolution: "typescript@patch:typescript@npm%3A4.2.4#~builtin<compat/typescript>::version=4.2.4&hash=34ad7d"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
   checksum: 083de437033ea11e57b0c66305a2c1d6d05e9383e57de2af405b0833ab68bd96d82d1f4f317fac06f3420410a006244648cf70278f58b3b4d55632dc7aeb8d4a
-  languageName: node
-  linkType: hard
-
-"typescript@patch:typescript@^4.3.1-rc#~builtin<compat/typescript>":
-  version: 4.3.1-rc
-  resolution: "typescript@patch:typescript@npm%3A4.3.1-rc#~builtin<compat/typescript>::version=4.3.1-rc&hash=34ad7d"
-  bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: dd8e72f0ba421eb192bf1c163d0f905901726e3c8cf75709c1164f83cc77fe4140ff5b7edbceb23f5cc47c89406f8e7bb64beb43a864cbbba79d0f1e11f9a0d9
   languageName: node
   linkType: hard
 
@@ -15107,7 +15087,7 @@ typescript@^4.3.1-rc:
     sass: ^1.32.13
     tailwindcss: ^2.1.2
     ts-jest: ^26.5.6
-    typescript: ^4.3.1-rc
+    typescript: 4.2.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Context

Vercel don't support yarn 2+ cache yet... 

The workaround is to save the cache in node_modules, ie: `yarn install` becomes `YARN_CACHE_FOLDER=./node_modules/.yarn-cache yarn install`.

### Bug

Setting YARN_CACHE_FOLDER will work, but not all the time, cause if a valid node_modules is not present initially it will fail

```
➤ YN0001: │ Error: While persisting /home/sebastien/github/nextjs-monorepo-example/node_modules
/.yarn-cache/@changesets-changelog-github-npm-0.4.0-8ea85c2012-ba451a77ca.zip
/node_modules/@changesets/changelog-github/ -> /home/sebastien/github/nextjs-monorepo-example
/node_modules/@changesets/changelog-github ENOENT: no such file or directory, 
scandir '/home/sebastien/github/nextjs-monorepo-example/node_modules/.yarn-cache/@changesets-changelog-github-npm-0.4.0-8ea85c2012-ba451a77ca.zip/node_modules/@changesets/changelog-github/'
```

### Reproduce

See https://github.com/belgattitude/nextjs-monorepo-example/pull/48

```
git clone https://github.com/belgattitude/nextjs-monorepo-example.git && cd nextjs-monorepo-example && git checkout -b fix-deps
```

Try this to reproduce:

```bash
$ YARN_CACHE_FOLDER=./node_modules/.yarn-cache yarn install
# -> BOOM will fail
```


PS: Weird, if your node_modules existed before it actually works:

```bash
$ yarn install
$ YARN_CACHE_FOLDER=./node_modules/.yarn-cache yarn install
# -> OK IT WORKS
```
But will fail if node_modules is not present (probably .yarn-state.yml)

```bash
$ yarn install
$  rm -rf ./node_modules && mkdir -p ./node_modules/.yarn-cache 
$ YARN_CACHE_FOLDER=./node_modules/.yarn-cache yarn install
# -> BOOM it fails
```