### PR TITLE
ci: cache for yarn is included in setup-node

### DIFF
--- a/.changeset/curly-countries-lick.md
+++ b/.changeset/curly-countries-lick.md
@@ -1,0 +1,9 @@
+---
+'blog-app': patch
+'web-app': patch
+'@your-org/core-lib': patch
+'@your-org/db-main-prisma': patch
+'@your-org/ui-lib': patch
+---
+
+CI: use built-in yarn cache from setup/node@v2.2

--- a/.github/workflows/ci-blog-app.yml
+++ b/.github/workflows/ci-blog-app.yml
@@ -42,24 +42,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      # Inspired by https://github.com/yarnpkg/berry/issues/954#issuecomment-629734719
-      - name: Restore yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
-            yarn-cache-folder-os-${{ runner.os }}-
+          cache: 'yarn'
 
       - name: Restore nextjs build blog-app from cache
         uses: actions/cache@v2

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -39,24 +39,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      # Inspired by https://github.com/yarnpkg/berry/issues/954#issuecomment-629734719
-      - name: Restore yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
-            yarn-cache-folder-os-${{ runner.os }}-
+          cache: 'yarn'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-web-app.yml
+++ b/.github/workflows/ci-web-app.yml
@@ -44,24 +44,10 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      # Inspired by https://github.com/yarnpkg/berry/issues/954#issuecomment-629734719
-      - name: Restore yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
-            yarn-cache-folder-os-${{ runner.os }}-
+          cache: 'yarn'
 
       - name: Restore nextjs build web-app from cache
         uses: actions/cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,25 +17,12 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
+
       - name: Use Node.js 14.x
-        uses: actions/setup-node@master
+        uses: actions/setup-node@v2
         with:
           node-version: 14.x
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      # Inspired by https://github.com/yarnpkg/berry/issues/954#issuecomment-629734719
-      - name: Restore yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
-            yarn-cache-folder-os-${{ runner.os }}-
+          cache: 'yarn'
 
       - name: Install Dependencies
         run: yarn install --immutable


### PR DESCRIPTION
setup-node@v2.2 has built-in cache for npm, yarn, yarn2: https://github.com/actions/setup-node/releases/tag/v2.2.0