### PR TITLE
[web-app] Allow to disable sentry from env 

### DIFF
--- a/.changeset/dull-starfishes-shake.md
+++ b/.changeset/dull-starfishes-shake.md
@@ -1,0 +1,5 @@
+---
+'web-app': patch
+---
+
+Allow sentry/nextjs to be disabled by env variables (ie: in for local builds or CI)

--- a/.github/workflows/ci-web-app.yml
+++ b/.github/workflows/ci-web-app.yml
@@ -88,14 +88,19 @@ jobs:
         run: |
           yarn build
         env:
+          NEXTJS_BUILD_TARGET: server
+          # Speed up build cause they are linted in a previous step
+          NEXTJS_IGNORE_ESLINT: 1
+          # Speed up build by not running sourcemap upload (not even dry-run)
           # Disable sourcemaps will speed up ci
           # be sure to disable it if you intent to use the build
           # done in this step (i.e: deploy, docker....)
           NEXT_DISABLE_SOURCEMAPS: 1
           NEXT_TELEMETRY_DISABLED: 0
-          # Speed up build cause they are linted in a previous step
-          NEXTJS_IGNORE_ESLINT: 1
-          NEXTJS_BUILD_TARGET: server
+          # Fully disable sentry registration here (no overhead in build time)
+          NEXT_DISABLE_SENTRY=1
+          # Disable sentry source map upload (when not needed)
+          NEXT_SENTRY_DRY_RUN=1
 
       - name: Check bundle size
         working-directory: apps/web-app

--- a/apps/web-app/.env
+++ b/apps/web-app/.env
@@ -7,6 +7,10 @@
 # @see https://www.prisma.io/docs/concepts/components/prisma-client/deployment#recommended-connection-limit
 PRISMA_DATABASE_URL=postgresql://nextjs:!ChangeMe!@localhost:5432/maindb?schema=public
 
-SENTRY_ENABLED=false
+# Fully disable sentry registration here (no overhead in build time)
+NEXT_DISABLE_SENTRY=1
+# Disable sentry source map upload (when not needed)
+NEXT_SENTRY_DRY_RUN=1
+
 SENTRY_RELEASE=
 NEXT_PUBLIC_SENTRY_DSN=

--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -134,9 +134,11 @@ const baseConfig = withTM({
 
 let config = baseConfig;
 
-if (process.env.SENTRY_ENABLED === 'true') {
+if (process.env.NEXT_DISABLE_SENTRY !== '1') {
   config = withSentryConfig(baseConfig, {
-    dryRun: process.env.NODE_ENV !== 'production',
+    dryRun:
+      process.env.NODE_ENV !== 'production' ||
+      process.env.NEXT_SENTRY_DRY_RUN === '1',
   });
 }
 


### PR DESCRIPTION
Added: 

```env
# Fully disable sentry registration here (no overhead in build time)
NEXT_DISABLE_SENTRY=1
# Disable sentry source map upload (when not needed)
NEXT_SENTRY_DRY_RUN=1
```

To control the registration of sentry and source map upload

Thanks Alecrae for pointing: https://github.com/getsentry/sentry-javascript/issues/3867