### PR TITLE
feat: use nextjs experimental externalDir

### DIFF
--- a/.changeset/many-tables-pretend.md
+++ b/.changeset/many-tables-pretend.md
@@ -1,0 +1,6 @@
+---
+'blog-app': minor
+'web-app': minor
+---
+
+Simplify setup, use NextJS 10.2+ experimental externalDirs option

--- a/README.md
+++ b/README.md
@@ -311,7 +311,23 @@ Inspiration can be found in [apps/web-app/tsconfig.json](./apps/web-app/tsconfig
 
 #### Step 3:
 
-Modify your `next.config.js` to import the tsconfig.json path aliases.
+Edit your `next.config.js` and enable the [experimental.externalDir option](https://github.com/vercel/next.js/pull/22867).
+Feedbacks [here](https://github.com/vercel/next.js/discussions/26420).
+
+```js
+const nextConfig = {
+  experimental: {
+    externalDir: true,
+  },
+};
+export default nextConfig;
+```
+
+<details>
+  <summary>Using a NextJs version prior to 10.2.0 ?</summary>
+
+If you're using an older NextJs version and don't have the experimental flag, you can simply override your
+webpack config.
 
 ```js
 const nextConfig = {
@@ -335,10 +351,10 @@ const nextConfig = {
 };
 ```
 
+</details>
+
 > PS:
 >
-> - NextJS 10.2+ [has an experimental.externalDir option](https://github.com/vercel/next.js/pull/22867) for monorepo,
->   when time comes it might allow to skip the webpack config override above.
 > - If your shared package make use of scss bundler... A custom webpack configuration will be necessary
 >   or use [next-transpile-modules](https://github.com/martpie/next-transpile-modules), see FAQ below.
 

--- a/apps/blog-app/next.config.js
+++ b/apps/blog-app/next.config.js
@@ -83,6 +83,7 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    externalDir: true,
   },
 
   eslint: {

--- a/apps/blog-app/next.config.js
+++ b/apps/blog-app/next.config.js
@@ -83,6 +83,7 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    // @link https://github.com/vercel/next.js/pull/22867
     externalDir: true,
   },
 
@@ -97,23 +98,6 @@ const nextConfig = {
 
   // @ts-ignore
   webpack: function (config, { defaultLoaders }) {
-    // This extra config allows to use paths defined in tsconfig
-    // rather than next-transpile-modules.
-    // @link https://github.com/vercel/next.js/pull/13542
-    const resolvedBaseUrl = path.resolve(config.context, '../../');
-    config.module.rules = [
-      ...config.module.rules,
-      {
-        test: /\.(tsx|ts|js|jsx|json)$/,
-        include: [resolvedBaseUrl],
-        use: defaultLoaders.babel,
-        // @ts-ignore
-        exclude: (excludePath) => {
-          return /node_modules/.test(excludePath);
-        },
-      },
-    ];
-
     config.module.rules.push({
       test: /\.svg$/,
       issuer: /\.(js|ts)x?$/,

--- a/apps/blog-app/next.config.js
+++ b/apps/blog-app/next.config.js
@@ -83,7 +83,9 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    // Experimental monorepo support
     // @link https://github.com/vercel/next.js/pull/22867
+    // @link https://github.com/vercel/next.js/discussions/26420
     externalDir: true,
   },
 

--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -87,6 +87,7 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    // @link https://github.com/vercel/next.js/pull/22867
     externalDir: true,
   },
 

--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -87,7 +87,9 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    // Experimental monorepo support
     // @link https://github.com/vercel/next.js/pull/22867
+    // @link https://github.com/vercel/next.js/discussions/26420
     externalDir: true,
   },
 

--- a/apps/web-app/next.config.js
+++ b/apps/web-app/next.config.js
@@ -87,6 +87,7 @@ const nextConfig = {
     // Prefer loading of ES Modules over CommonJS
     // @link https://nextjs.org/blog/next-11-1#es-modules-support
     esmExternals: false,
+    externalDir: true,
   },
 
   // @link https://nextjs.org/docs/basic-features/image-optimization
@@ -111,23 +112,6 @@ const nextConfig = {
 
   // @ts-ignore
   webpack: (config, { defaultLoaders, isServer }) => {
-    // This extra config allows to use paths defined in tsconfig
-    // rather than next-transpile-modules.
-    // @link https://github.com/vercel/next.js/pull/13542
-    const resolvedBaseUrl = path.resolve(config.context, '../../');
-    config.module.rules = [
-      ...config.module.rules,
-      {
-        test: /\.(tsx|ts|js|jsx|json)$/,
-        include: [resolvedBaseUrl],
-        use: defaultLoaders.babel,
-        // @ts-ignore
-        exclude: (excludePath) => {
-          return /node_modules/.test(excludePath);
-        },
-      },
-    ];
-
     // A temp workaround for https://github.com/prisma/prisma/issues/6899#issuecomment-849126557
     if (isServer) {
       config.externals.push('_http_common');


### PR DESCRIPTION
## Purpose

Trying out recent externalDir offered by NextJs: https://github.com/vercel/next.js/pull/22867. It works mostly perfect (multiple logs about babel) and offer comparable speed.



## Benchmarks

### With experimental/externalDirs

**FIRST BUILD: 22 seconds **:
**(mean ± σ): 9 seconds**:

![Selection_220](https://user-images.githubusercontent.com/259798/129395467-54422bce-8415-4a6e-9802-d52f7aea5408.png)


### With previous implementation (webpack)

<details>
<summary>Example of next.config.js overrides</summary>

```js 
const nextConfig = {
  webpack: function (config, { defaultLoaders }) {
    // This extra config allows to use paths defined in tsconfig
    // @link https://github.com/vercel/next.js/pull/13542
    const resolvedBaseUrl = path.resolve(config.context, '../../');
    config.module.rules = [
      ...config.module.rules,
      {
        test: /\.(tsx|ts|js|jsx|json)$/,
        include: [resolvedBaseUrl],
        use: defaultLoaders.babel,
        exclude: (excludePath) => {
          return /node_modules/.test(excludePath);
        },
      },
    ];
    return config;
  },
};

``` 
</details>

**FIRST BUILD: 22 seconds **:
**(mean ± σ): 9 seconds**:

![Selection_221](https://user-images.githubusercontent.com/259798/129396078-03df8fb2-2b3c-4551-8d22-80f2a73d6990.png)

## Notes

An **info** appears in the log it seems it loads babel multiple times

``` 
info  - Using external babel configuration from /home/sebastien/github/nextjs-monorepo-example/apps/web-app/babel.config.js

```

![Selection_222](https://user-images.githubusercontent.com/259798/129396311-f52ad377-a14a-4a0e-8b1d-eef66611da00.png)
