### PR TITLE
ci: increase performance of yarn cache (restore keys)

### DIFF
--- a/.github/workflows/ci-blog-app.yml
+++ b/.github/workflows/ci-blog-app.yml
@@ -46,14 +46,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Why not using setup-node 2.2+ cache option (yet) ?
+      # see https://github.com/belgattitude/nextjs-monorepo-example/pull/369
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      # While setup-node action has a cache option since v2.2.0 for yarn which makes
-      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
-      # and so yarn has to download again deps (rather than reusing / managing the
-      # .yarn/cache/*.zip that it already have)
       - name: Restore yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
@@ -63,7 +61,6 @@ jobs:
           restore-keys: |
             yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
             yarn-cache-folder-os-${{ runner.os }}-
-
 
       # see https://github.com/vercel/next.js/pull/27362
       - name: Restore nextjs build blog-app from cache

--- a/.github/workflows/ci-blog-app.yml
+++ b/.github/workflows/ci-blog-app.yml
@@ -45,7 +45,25 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      # While setup-node action has a cache option since v2.2.0 for yarn which makes
+      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
+      # and so yarn has to download again deps (rather than reusing / managing the
+      # .yarn/cache/*.zip that it already have)
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
+
 
       # see https://github.com/vercel/next.js/pull/27362
       - name: Restore nextjs build blog-app from cache

--- a/.github/workflows/ci-monorepo-integrity.yml
+++ b/.github/workflows/ci-monorepo-integrity.yml
@@ -33,7 +33,22 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+
+      # Why not using setup-node 2.2+ cache option (yet) ?
+      # see https://github.com/belgattitude/nextjs-monorepo-example/pull/369
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -42,7 +42,24 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      # While setup-node action has a cache option since v2.2.0 for yarn which makes
+      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
+      # and so yarn has to download again deps (rather than reusing / managing the
+      # .yarn/cache/*.zip that it already have)
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -43,14 +43,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Why not using setup-node 2.2+ cache option (yet) ?
+      # see https://github.com/belgattitude/nextjs-monorepo-example/pull/369
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      # While setup-node action has a cache option since v2.2.0 for yarn which makes
-      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
-      # and so yarn has to download again deps (rather than reusing / managing the
-      # .yarn/cache/*.zip that it already have)
       - name: Restore yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/ci-web-app.yml
+++ b/.github/workflows/ci-web-app.yml
@@ -47,7 +47,24 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      # While setup-node action has a cache option since v2.2.0 for yarn which makes
+      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
+      # and so yarn has to download again deps (rather than reusing / managing the
+      # .yarn/cache/*.zip that it already have)
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
 
       # see https://github.com/vercel/next.js/pull/27362
       - name: Restore nextjs build web-app from cache

--- a/.github/workflows/ci-web-app.yml
+++ b/.github/workflows/ci-web-app.yml
@@ -48,14 +48,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      # Why not using setup-node 2.2+ cache option (yet) ?
+      # see https://github.com/belgattitude/nextjs-monorepo-example/pull/369
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      # While setup-node action has a cache option since v2.2.0 for yarn which makes
-      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
-      # and so yarn has to download again deps (rather than reusing / managing the
-      # .yarn/cache/*.zip that it already have)
       - name: Restore yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,12 @@ jobs:
         with:
           node-version: 14.x
 
+      # Why not using setup-node 2.2+ cache option (yet) ?
+      # see https://github.com/belgattitude/nextjs-monorepo-example/pull/369
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
 
-      # While setup-node action has a cache option since v2.2.0 for yarn which makes
-      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
-      # and so yarn has to download again deps (rather than reusing / managing the
-      # .yarn/cache/*.zip that it already have)
       - name: Restore yarn cache
         uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
 
-
       - name: Use Node.js 14.x
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,24 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
-          cache: 'yarn'
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      # While setup-node action has a cache option since v2.2.0 for yarn which makes
+      # config shorter. It seems to invalidate the cache whenever yarn.lock changes,
+      # and so yarn has to download again deps (rather than reusing / managing the
+      # .yarn/cache/*.zip that it already have)
+      - name: Restore yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-${{ hashFiles('**/yarn.lock', '.yarnrc.yml') }}
+          restore-keys: |
+            yarn-cache-folder-os-${{ runner.os }}-node-${{ env.node-version }}-
+            yarn-cache-folder-os-${{ runner.os }}-
 
       - name: Install Dependencies
         run: yarn install --immutable

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -133,6 +133,7 @@
     "react-i18next": "11.11.4",
     "react-query": "3.21.1",
     "sharp": "0.29.0",
+    "superjson": "1.7.5",
     "type-fest": "2.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15826,6 +15826,16 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
+"superjson@npm:1.7.5":
+  version: 1.7.5
+  resolution: "superjson@npm:1.7.5"
+  dependencies:
+    debug: ^4.3.1
+    lodash.clonedeep: ^4.5.0
+  checksum: 629c3cf3343203f8ab585046a7dfb9c730df3e08b00f4e78a029ddf148f93c22c65e0455dc4a7c6a72b3228dd9a8b39ff46ed5845ca555c14e92d85e02d2cae5
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -17128,6 +17138,7 @@ resolve@^2.0.0-next.3:
     sharp: 0.29.0
     shell-quote: 1.7.2
     size-limit: 5.0.3
+    superjson: 1.7.5
     symlink-dir: 5.0.1
     sync-directory: 2.2.22
     tailwindcss: 2.2.9


### PR DESCRIPTION
Since v2.2 the setup-node action supports a cache option that was used here... 

Unfortunately whenever the yarn.lock change, it restarts a full install (fetch packages) cause the cache is invalidated.

```
// Example of full install
Run yarn install --immutable
➤ YN0000: ┌ Fetch step
➤ YN0013: │ 5 packages were already cached, 1719 had to be fetched
➤ YN0000: └ Completed in 1m 28s

// github cache post restore: Post job cleanup. 
// Cache Size: ~127 MB (133205960 B)
// Key: yarn-cache-folder-os-Linux-node--4445ea8d47711d224cff8a70fba58ae88caf219086b2f3596112b143ffa3fc37
``` 

In Yarn 2+ and 3+ with the `.yarn/cache/*.zip` support, it should possible to avoid this. Yarn seems to be able to properly add / change / cleanup its own managed cache folder.

So the idea is to use the action/cache and play with restore-keys..

**Results:**

When cache available , works perfect :+1:  

```
Run yarn install --immutable
➤ YN0000: ┌ Fetch step
  ➤ YN0013: │ 1719 packages were already cached
➤ YN0000: └ Completed in 0s 727ms

// Cache hit occurred on the primary key yarn-cache-folder-os-Linux-node--4445ea8d47711d224cff8a70fba58ae88caf219086b2f3596112b143ffa3fc37, not saving cache.
```

When `yarn.lock` is changed (example adding superjson), works perfect :+1: 

```
yarn install --immutable
➤ YN0000: ┌ Fetch step
  ➤ YN0013: │ 1719 packages were already cached, one had to be fetched (superjson@npm:1.7.5)
➤ YN0000: └ Completed in 1s 124ms

Cache Size: ~127 MB (133261279 B)
Cache saved successfully
Cache saved with key: yarn-cache-folder-os-Linux-node--f118ea4bee07eada9df36ad2e83fd6febcbaf06b5b8962689c7650659e872ad3
```

