### PR TITLE
chore(yarn): perf use nmMode hardlinks-local

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -4,6 +4,8 @@ enableGlobalCache: false
 
 nodeLinker: node-modules
 
+nmMode: hardlinks-local
+
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-interactive-tools.cjs
     spec: "@yarnpkg/plugin-interactive-tools"


### PR DESCRIPTION
Testing the [`nmMode: hardlinks-local`](https://yarnpkg.com/configuration/yarnrc#nmMode) option.

Save a bit of bytes: global node-modules size went from 845Mb to 774Mb... 

