### PR TITLE
chore(eslint): only run testing-library on test files

### DIFF
--- a/.changeset/cuddly-balloons-punch.md
+++ b/.changeset/cuddly-balloons-punch.md
@@ -1,0 +1,9 @@
+---
+'blog-app': minor
+'web-app': minor
+'@your-org/core-lib': minor
+'@your-org/ui-lib': minor
+'@your-org/db-main-prisma': minor
+---
+
+Eslint performance by not running test plugins over regular code

--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -27,9 +27,11 @@ module.exports = {
     'plugin:import/typescript',
     'plugin:@typescript-eslint/recommended',
     'plugin:prettier/recommended',
-    'plugin:jest/recommended',
-    'plugin:sonarjs/recommended',
   ],
+  // By loading jest and sonarjs globally as a plugin
+  // we can load recommended on specific code base (regular / tests) through
+  // overrides.
+  plugins: ['jest', 'sonarjs'],
   globals: {
     context: 'readonly',
     cy: 'readonly',
@@ -65,6 +67,27 @@ module.exports = {
   },
   overrides: [
     {
+      // For performance run sonarjs/recommended on regular code, not test files.
+      files: ['**/*.[jt]s?(x)'],
+      extends: ['plugin:sonarjs/recommended'],
+      rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-object-literal-type-assertion': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+      },
+    },
+    {
+      // For performance run jest/recommended on test files, not regular code
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(test).[jt]s?(x)'],
+      extends: ['plugin:jest/recommended'],
+      rules: {
+        '@typescript-eslint/no-non-null-assertion': 'off',
+        '@typescript-eslint/no-object-literal-type-assertion': 'off',
+        '@typescript-eslint/no-empty-function': 'off',
+      },
+    },
+
+    {
       files: ['*.config.js', '**/jest/**/*.js'],
       parser: 'espree',
       parserOptions: {
@@ -76,14 +99,6 @@ module.exports = {
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         'sonarjs/no-duplicate-string': 'off',
         'sonarjs/no-all-duplicated-branches': 'off',
-      },
-    },
-    {
-      files: ['*.test.ts', '*.test.tsx'],
-      rules: {
-        '@typescript-eslint/no-non-null-assertion': 'off',
-        '@typescript-eslint/no-object-literal-type-assertion': 'off',
-        '@typescript-eslint/no-empty-function': 'off',
       },
     },
   ],

--- a/apps/blog-app/.eslintrc.js
+++ b/apps/blog-app/.eslintrc.js
@@ -8,8 +8,10 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:@next/next/recommended',
-    'plugin:testing-library/react',
   ],
+  // By loading testing-library as a plugin, we can only enable it
+  // on test files via overrides.
+  plugins: ['testing-library'],
   env: {
     browser: true,
     es6: true,
@@ -26,6 +28,11 @@ module.exports = {
     '@next/next/no-img-element': 'off',
   },
   overrides: [
+    {
+      // For performance run jest/recommended on test files, not regular code
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(test).[jt]s?(x)'],
+      extends: ['plugin:testing-library/react'],
+    },
     {
       files: ['next.config.js'],
       parser: 'espree',

--- a/apps/web-app/.eslintrc.js
+++ b/apps/web-app/.eslintrc.js
@@ -8,8 +8,10 @@ module.exports = {
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
     'plugin:@next/next/recommended',
-    'plugin:testing-library/react',
   ],
+  // By loading testing-library as a plugin, we can only enable it
+  // on test files via overrides.
+  plugins: ['testing-library'],
   env: {
     browser: true,
     es6: true,
@@ -26,6 +28,11 @@ module.exports = {
     '@next/next/no-img-element': 'off',
   },
   overrides: [
+    {
+      // For performance run jest/recommended on test files, not regular code
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(test).[jt]s?(x)'],
+      extends: ['plugin:testing-library/react'],
+    },
     {
       files: ['next.config.js'],
       parser: 'espree',

--- a/packages/core-lib/.eslintrc.js
+++ b/packages/core-lib/.eslintrc.js
@@ -7,8 +7,10 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
-    'plugin:testing-library/react',
   ],
+  // By loading testing-library as a plugin, we can only enable it
+  // on test files via overrides.
+  plugins: ['testing-library'],
   env: {
     browser: true,
     es6: true,
@@ -19,5 +21,11 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'jsx-a11y/anchor-is-valid': 'off',
   },
-  overrides: [],
+  overrides: [
+    {
+      // For performance run jest/recommended on test files, not regular code
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+      extends: ['plugin:testing-library/react'],
+    },
+  ],
 };

--- a/packages/ui-lib/.eslintrc.js
+++ b/packages/ui-lib/.eslintrc.js
@@ -7,8 +7,10 @@ module.exports = {
     'plugin:react/recommended',
     'plugin:react-hooks/recommended',
     'plugin:jsx-a11y/recommended',
-    'plugin:testing-library/react',
   ],
+  // By loading testing-library as a plugin, we can only enable it
+  // on test files via overrides.
+  plugins: ['testing-library'],
   env: {
     browser: true,
     es6: true,
@@ -19,5 +21,11 @@ module.exports = {
     'react/react-in-jsx-scope': 'off',
     'jsx-a11y/anchor-is-valid': 'off',
   },
-  overrides: [],
+  overrides: [
+    {
+      // For performance run jest/recommended on test files, not regular code
+      files: ['**/__tests__/**/*.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
+      extends: ['plugin:testing-library/react'],
+    },
+  ],
 };


### PR DESCRIPTION
Performance and clarity. Some plugins does not need to be run on code or test files.

jest/recommended and react-testing library only enabled for .test.ts(x) files. 

sonarjs/recommended only on regular code