### PR TITLE
[Bug reproduction] next-i18next 

### DIFF
--- a/apps/web-app/public/locales/en/home.json
+++ b/apps/web-app/public/locales/en/home.json
@@ -2,6 +2,10 @@
   "page": {
     "title": "Home | Web-app | nextjs-monorepo-example"
   },
+  "msg": {
+    "title": "I speak english",
+    "subtitle": "<0>Basically</0> every <2>Day</2>"
+  },
   "btn": {
     "getStarted": "Get started",
     "liveDemo": "Live demo"

--- a/apps/web-app/public/locales/fr/home.json
+++ b/apps/web-app/public/locales/fr/home.json
@@ -2,6 +2,10 @@
   "page": {
     "title": "Accueil | Web-app | nextjs-monorepo-example"
   },
+  "msg": {
+    "title": "Je parle français",
+    "subtitle": "<0>Quasiment</0> chaque <2>Jour</2>"
+  },
   "btn": {
     "getStarted": "Démarrer",
     "liveDemo": "Démo"

--- a/apps/web-app/src/components/test/test-comp.tsx
+++ b/apps/web-app/src/components/test/test-comp.tsx
@@ -1,0 +1,12 @@
+import { useTranslation } from 'next-i18next';
+import { FC } from 'react';
+//import { useTranslation } from 'react-i18next';
+
+export const TestComp: FC = () => {
+  const { t } = useTranslation(['home']);
+  return (
+    <div>
+      <h1>{t('home:msg.title')}</h1>
+    </div>
+  );
+};

--- a/apps/web-app/src/components/test/test-comp2.tsx
+++ b/apps/web-app/src/components/test/test-comp2.tsx
@@ -1,0 +1,13 @@
+import { Trans } from 'next-i18next';
+import { FC } from 'react';
+//import { Trans } from 'react-i18next';
+
+export const TestComp2: FC = () => {
+  return (
+    <div>
+      <Trans ns={'home'} i18nKey={'msg.subtitle'}>
+        <strong>Basically</strong> every <strong>day</strong>
+      </Trans>
+    </div>
+  );
+};

--- a/apps/web-app/src/components/test/test-comp3.tsx
+++ b/apps/web-app/src/components/test/test-comp3.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+//import { useTranslation } from 'next-i18next';
+
+export const TestComp3: FC = () => {
+  const { t } = useTranslation(['home']);
+  return (
+    <div>
+      <h1>{t('home:msg.title')}</h1>
+    </div>
+  );
+};

--- a/apps/web-app/src/pages/i18n.tsx
+++ b/apps/web-app/src/pages/i18n.tsx
@@ -1,0 +1,36 @@
+import { BadRequest } from '@tsed/exceptions';
+import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
+import { TestComp } from '@/components/test/test-comp';
+import { TestComp2 } from '@/components/test/test-comp2';
+import { TestComp3 } from '@/components/test/test-comp3';
+
+type Props = {
+  /** Add HomeRoute props here */
+};
+
+export default function I18nRoute(
+  _props: InferGetServerSidePropsType<typeof getServerSideProps>
+) {
+  return (
+    <div>
+      <TestComp />
+      <TestComp2 />
+      <TestComp3 />
+    </div>
+  );
+}
+
+export const getServerSideProps: GetServerSideProps<Props> = async (
+  context
+) => {
+  const { locale } = context;
+  if (locale === undefined) {
+    throw new BadRequest('locale is missing');
+  }
+  return {
+    props: {
+      ...(await serverSideTranslations(locale, ['home', 'common'].slice())),
+    },
+  };
+};


### PR DESCRIPTION

Quick try

```bash
cd apps/web-app
yarn install && yarn dedupe && yarn clean && yarn dev
```

Output log

```
(...)
event - build page: /i18n
wait  - compiling...
event - compiled successfully
react-i18next:: You will need to pass in an i18next instance by using initReactI18next
wait  - compiling...
event - compiled successfully
```