### PR TITLE
chore(dev-deps): add convenience @types/jest

### DIFF
--- a/apps/blog-app/package.json
+++ b/apps/blog-app/package.json
@@ -56,6 +56,7 @@
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
+    "@types/jest": "27.0.2",
     "@types/node": "16.10.1",
     "@types/react": "17.0.27",
     "@types/react-dom": "17.0.9",

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -62,6 +62,7 @@
     "@testing-library/react-hooks": "7.0.2",
     "@types/cors": "2.8.12",
     "@types/graphql": "14.5.0",
+    "@types/jest": "27.0.2",
     "@types/node": "16.10.1",
     "@types/react": "17.0.27",
     "@types/react-dom": "17.0.9",

--- a/packages/core-lib/package.json
+++ b/packages/core-lib/package.json
@@ -37,6 +37,7 @@
     "@testing-library/jest-dom": "5.14.1",
     "@testing-library/react": "12.1.2",
     "@testing-library/react-hooks": "7.0.2",
+    "@types/jest": "27.0.2",
     "@types/node": "16.10.1",
     "@types/react": "17.0.27",
     "@types/react-dom": "17.0.9",

--- a/packages/db-main-prisma/package.json
+++ b/packages/db-main-prisma/package.json
@@ -32,6 +32,7 @@
     "fix:all-files": "eslint . --ext .ts,.tsx,.js,.jsx --fix"
   },
   "devDependencies": {
+    "@types/jest": "27.0.2",
     "@types/node": "16.10.1",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -65,5 +65,8 @@
   "peerDependencies": {
     "react": "^16.14.0 || ^17.0.2",
     "react-dom": "^16.14.0 || ^17.0.2"
+  },
+  "dependencies": {
+    "@types/jest": "27.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2406,19 +2406,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^26.6.2":
-  version: 26.6.2
-  resolution: "@jest/types@npm:26.6.2"
-  dependencies:
-    "@types/istanbul-lib-coverage": ^2.0.0
-    "@types/istanbul-reports": ^3.0.0
-    "@types/node": "*"
-    "@types/yargs": ^15.0.0
-    chalk: ^4.0.0
-  checksum: a0bd3d2f22f26ddb23f41fddf6e6a30bf4fab2ce79ec1cb6ce6fdfaf90a72e00f4c71da91ec61e13db3b10c41de22cf49d07c57ff2b59171d64b29f909c1d8d6
-  languageName: node
-  linkType: hard
-
 "@jest/types@npm:^27.2.5":
   version: 27.2.5
   resolution: "@jest/types@npm:27.2.5"
@@ -3764,13 +3751,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:*":
-  version: 26.0.23
-  resolution: "@types/jest@npm:26.0.23"
+"@types/jest@npm:*, @types/jest@npm:27.0.2":
+  version: 27.0.2
+  resolution: "@types/jest@npm:27.0.2"
   dependencies:
-    jest-diff: ^26.0.0
-    pretty-format: ^26.0.0
-  checksum: 69db26061e6be34de2a440c8a470b651c53ba6ee0057614a278c4f756ff00281f46cc075b24e5bd761f399f175f49d0a5758b50dd921342a8592461548dea29a
+    jest-diff: ^27.0.0
+    pretty-format: ^27.0.0
+  checksum: 814ad5f5d2f277849f47e52906da4b745758e555630fc8cb46a071bde648eefeffb1b35710c530a8cea7fc4ea7c1d813812c120484bf7902ab6c5e473cdd49c9
   languageName: node
   linkType: hard
 
@@ -3969,15 +3956,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^15.0.0":
-  version: 15.0.13
-  resolution: "@types/yargs@npm:15.0.13"
-  dependencies:
-    "@types/yargs-parser": "*"
-  checksum: a6ebb0ec63f168280e02370fcf24ff29c3eb0335e1c46e3b34e04d32eb7c818446e0b7de8badb339b07c0ddba322827ce13ccb604d14a0de422335ae56b2120d
-  languageName: node
-  linkType: hard
-
 "@types/yargs@npm:^16.0.0":
   version: 16.0.3
   resolution: "@types/yargs@npm:16.0.3"
@@ -4102,6 +4080,7 @@ __metadata:
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
     "@tsed/exceptions": ^6.72.1
+    "@types/jest": 27.0.2
     "@types/node": 16.10.1
     "@types/react": 17.0.27
     "@types/react-dom": 17.0.9
@@ -4147,6 +4126,7 @@ __metadata:
   resolution: "@your-org/db-main-prisma@workspace:packages/db-main-prisma"
   dependencies:
     "@prisma/client": 3.2.1
+    "@types/jest": 27.0.2
     "@types/node": 16.10.1
     "@typescript-eslint/eslint-plugin": 4.33.0
     "@typescript-eslint/parser": 4.33.0
@@ -4183,6 +4163,7 @@ __metadata:
     "@testing-library/jest-dom": 5.14.1
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
+    "@types/jest": 27.0.2
     "@types/node": 16.10.1
     "@types/react": 17.0.27
     "@types/react-dom": 17.0.9
@@ -5180,6 +5161,7 @@ __metadata:
     "@testing-library/jest-dom": 5.14.1
     "@testing-library/react": 12.1.2
     "@testing-library/react-hooks": 7.0.2
+    "@types/jest": 27.0.2
     "@types/node": 16.10.1
     "@types/react": 17.0.27
     "@types/react-dom": 17.0.9
@@ -7144,13 +7126,6 @@ __metadata:
   version: 1.2.2
   resolution: "didyoumean@npm:1.2.2"
   checksum: d5d98719d58b3c2fa59663c4c42ba9716f1fd01245c31d5fce31915bd3aa26e6aac149788e007358f778ebbd68a2256eb5973e8ca6f221df221ba060115acf2e
-  languageName: node
-  linkType: hard
-
-"diff-sequences@npm:^26.6.2":
-  version: 26.6.2
-  resolution: "diff-sequences@npm:26.6.2"
-  checksum: 79af871776ef149a7ff3345d6b1bf37fe6e81f68632aa5542787851f6f60fba19b0be22fdd1e06046f56ae7382763ccfe94a982c39ee72bd107aef435ecbc0cf
   languageName: node
   linkType: hard
 
@@ -10116,19 +10091,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-diff@npm:^26.0.0":
-  version: 26.6.2
-  resolution: "jest-diff@npm:26.6.2"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^26.6.2
-    jest-get-type: ^26.3.0
-    pretty-format: ^26.6.2
-  checksum: d00d297f31e1ac0252127089892432caa7a11c69bde29cf3bb6c7a839c8afdb95cf1fd401f9df16a4422745da2e6a5d94b428b30666a2540c38e1c5699915c2d
-  languageName: node
-  linkType: hard
-
-"jest-diff@npm:^27.2.5":
+"jest-diff@npm:^27.0.0, jest-diff@npm:^27.2.5":
   version: 27.2.5
   resolution: "jest-diff@npm:27.2.5"
   dependencies:
@@ -10188,13 +10151,6 @@ __metadata:
     jest-mock: ^27.2.5
     jest-util: ^27.2.5
   checksum: 74acc3fe1d4f7a9cf84298b845db4394234f66f91c2453d0803a8a97e8db2f9908f98c711dc04ff9b189ec97b28b8a2666aee4649b38bf1143bb646eec2ab306
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^26.3.0":
-  version: 26.3.0
-  resolution: "jest-get-type@npm:26.3.0"
-  checksum: 1cc6465ae4f5e880be22ba52fd270fa64c21994915f81b41f8f7553a7957dd8e077cc8d03035de9412e2d739f8bad6a032ebb5dab5805692a5fb9e20dd4ea666
   languageName: node
   linkType: hard
 
@@ -14271,19 +14227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^26.0.0, pretty-format@npm:^26.6.2":
-  version: 26.6.2
-  resolution: "pretty-format@npm:26.6.2"
-  dependencies:
-    "@jest/types": ^26.6.2
-    ansi-regex: ^5.0.0
-    ansi-styles: ^4.0.0
-    react-is: ^17.0.1
-  checksum: e3b808404d7e1519f0df1aa1f25cee0054ab475775c6b2b8c5568ff23194a92d54bf93274139b6f584ca70fd773be4eaa754b0e03f12bb0a8d1426b07f079976
-  languageName: node
-  linkType: hard
-
-"pretty-format@npm:^27.0.2, pretty-format@npm:^27.2.5":
+"pretty-format@npm:^27.0.0, pretty-format@npm:^27.0.2, pretty-format@npm:^27.2.5":
   version: 27.2.5
   resolution: "pretty-format@npm:27.2.5"
   dependencies:
@@ -17629,6 +17573,7 @@ resolve@^2.0.0-next.3:
     "@tsed/exceptions": 6.73.9
     "@types/cors": 2.8.12
     "@types/graphql": 14.5.0
+    "@types/jest": 27.0.2
     "@types/node": 16.10.1
     "@types/react": 17.0.27
     "@types/react-dom": 17.0.9


### PR DESCRIPTION
Jest 27+ has builtin typescript types... 

But in some circumstances (mostly depending on package manager version and flavours), it seems that test files complains about missing @types/jest. The culprit is probably related to this https://www.npmjs.com/package/@types/testing-library__jest-dom

## Packages managers issues

Mostly about typechecks, as an example:

```
Run yarn typecheck
Error: jest.config.js(20,19): error TS2307: Cannot find module '@jest/types' or its corresponding type declarations.
Error: src/components/layout/__tests__/main-layout.test.tsx(4,1): error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
```

- yarn 3.1.0-rc.8 works when **`nmLinker: node_modules`**
- yarn 3.1.0-rc.8 complains when **`nmLinker: pnpm`**