### PR TITLE
chore(lint-staged): run eslint with cache in lint-staged

### DIFF
--- a/.github/workflows/ci-web-app.yml
+++ b/.github/workflows/ci-web-app.yml
@@ -89,7 +89,6 @@ jobs:
       - name: Linter
         working-directory: apps/web-app
         run: |
-          ls -la
           yarn lint --cache
 
       - name: Unit tests


### PR DESCRIPTION
commit hook will be faster... cause now it's a bit slow