### PR TITLE
chore: add vscode config file to include eslint working directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ yarn-error.log*
 *.launch
 *.sublime-workspace
 
-.vscode/
+.vscode/*
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "eslint.workingDirectories": [
+    {
+      "pattern": "./apps/*/"
+    },
+    {
+      "pattern": "./packages/*/"
+    }
+  ]
+}


### PR DESCRIPTION
Include VSCode configuration file based on Readme configuration. Based on 
https://github.com/belgattitude/nextjs-monorepo-example/pull/737#issuecomment-960242070

Let me check if this helps!

Thanks for your awesome monorepo!