### PR TITLE
feat: improve monorepo support for eslint

### DIFF
--- a/.changeset/thin-berries-beam.md
+++ b/.changeset/thin-berries-beam.md
@@ -1,0 +1,5 @@
+---
+"@your-org/eslint-config-bases": minor
+---
+
+Export '/patch/modern-module-resolution' based on @rushstack/eslint-patch

--- a/apps/nextjs-app/.eslintrc.js
+++ b/apps/nextjs-app/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/apps/remix-app/.eslintrc.js
+++ b/apps/remix-app/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/apps/vite-app/.eslintrc.js
+++ b/apps/vite-app/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/packages/api-gateway/.eslintrc.js
+++ b/packages/api-gateway/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/packages/core-lib/.eslintrc.js
+++ b/packages/core-lib/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/packages/db-main-prisma/.eslintrc.js
+++ b/packages/db-main-prisma/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/packages/eslint-config-bases/README.md
+++ b/packages/eslint-config-bases/README.md
@@ -13,16 +13,20 @@ packages that lives in a [monorepo](https://github.com/belgattitude/nextjs-monor
 
 ## Features
 
-- **Customizable:** Simply extends the bases and fine-tune them.
-- **Composable:** Add only what you need. Less unwanted side effects, increase perf.
-- **Conventions:** Plugins enabled on file conventions patterns to increase perf.
-- **Ease:** No need to install all the plugins in consuming apps/packages.
-- **Monorepo:** Change detection aware.
+## Features
+
+- **Monorepo friendly:** Each workspace can have its own config.
+- **Composable:** Compose your workspace eslint config from pre-defined bases.
+- **Peace of mind:** Plugins does not need to be installed per workspaces, thx to [@rushstack/eslint-patch](https://www.npmjs.com/package/@rushstack/eslint-patch).
+- **Performance:** Plugins enabled on file conventions patterns to increase perf.
 
 ## Install
 
+Add the following devDependencies to workspace (apps/packages in monorepo) or main project package.json.
+
 ```bash
-$ yarn add --dev eslint @your-org/eslint-config-bases:"workspace:^"
+$ yarn add --dev eslint
+$ yarn add --dev @your-org/eslint-config-bases:"workspace:^"
 ```
 
 > **Tip** the [workspace:^](https://yarnpkg.com/features/workspaces#workspace-ranges-workspace) is supported by yarn and pnpm.
@@ -33,6 +37,9 @@ In your app or package, create an `./apps/my-app/.eslintrc.js` file that extends
 existing base configs. For example:
 
 ```javascript
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require("@your-org/eslint-config-bases/patch/modern-module-resolution");
+
 module.exports = {
   // Be sure to set root to true in monorepo.
   root: true,

--- a/packages/eslint-config-bases/package.json
+++ b/packages/eslint-config-bases/package.json
@@ -19,6 +19,9 @@
     ".": {
       "require": "./src/index.js"
     },
+    "./patch/modern-module-resolution": {
+      "require": "./src/patch/modern-module-resolution.js"
+    },
     "./helpers": {
       "require": "./src/helpers/index.js"
     },
@@ -63,32 +66,28 @@
     "fix-all-files": "eslint  --ext .ts,.tsx,.js,.jsx --fix"
   },
   "dependencies": {
-    "@graphql-eslint/eslint-plugin": "3.10.4",
-    "@testing-library/jest-dom": "5.16.4",
-    "@testing-library/react": "13.3.0",
-    "@testing-library/react-hooks": "8.0.1",
-    "@types/jest": "28.1.4",
-    "@types/node": "18.0.0",
-    "@types/react": "18.0.15",
-    "@types/react-dom": "18.0.6",
-    "@typescript-eslint/eslint-plugin": "5.30.5",
-    "@typescript-eslint/parser": "5.30.5",
-    "eslint-config-prettier": "8.5.0",
-    "eslint-import-resolver-typescript": "3.2.5",
-    "eslint-plugin-import": "2.26.0",
-    "eslint-plugin-jest": "26.5.3",
-    "eslint-plugin-jest-formatting": "3.1.0",
-    "eslint-plugin-jsx-a11y": "6.6.0",
-    "eslint-plugin-playwright": "0.9.0",
-    "eslint-plugin-prettier": "4.2.1",
-    "eslint-plugin-react": "7.30.1",
-    "eslint-plugin-react-hooks": "4.6.0",
-    "eslint-plugin-regexp": "1.7.0",
-    "eslint-plugin-sonarjs": "0.13.0",
-    "eslint-plugin-tailwindcss": "3.6.0",
-    "eslint-plugin-testing-library": "5.5.1",
-    "prettier": "2.7.1",
-    "rimraf": "3.0.2"
+    "@graphql-eslint/eslint-plugin": "^3.10.4",
+    "@rushstack/eslint-patch": "^1.1.0",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^13.3.0",
+    "@testing-library/react-hooks": "^8.0.1",
+    "@typescript-eslint/eslint-plugin": "^5.30.5",
+    "@typescript-eslint/parser": "^5.30.5",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-import-resolver-typescript": "^3.2.5",
+    "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-jest": "^26.5.3",
+    "eslint-plugin-jest-formatting": "^3.1.0",
+    "eslint-plugin-jsx-a11y": "^6.6.0",
+    "eslint-plugin-playwright": "^0.9.0",
+    "eslint-plugin-prettier": "^4.2.1",
+    "eslint-plugin-react": "^7.30.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-regexp": "^1.7.0",
+    "eslint-plugin-sonarjs": "^0.13.0",
+    "eslint-plugin-tailwindcss": "^3.6.0",
+    "eslint-plugin-testing-library": "^5.5.1",
+    "prettier": "^2.7.1"
   },
   "peerDependencies": {
     "eslint": "^8.0.0",
@@ -112,11 +111,16 @@
     }
   },
   "devDependencies": {
+    "@types/jest": "28.1.4",
+    "@types/node": "18.0.0",
     "@types/prettier": "2.6.3",
+    "@types/react": "18.0.15",
+    "@types/react-dom": "18.0.6",
     "eslint": "8.19.0",
     "graphql": "16.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "rimraf": "3.0.2",
     "typescript": "4.7.4"
   }
 }

--- a/packages/eslint-config-bases/src/patch/modern-module-resolution.js
+++ b/packages/eslint-config-bases/src/patch/modern-module-resolution.js
@@ -1,0 +1,3 @@
+// See https://www.npmjs.com/package/@rushstack/eslint-patch
+// @ts-ignore
+require('@rushstack/eslint-patch/modern-module-resolution');

--- a/packages/ui-lib/.eslintrc.js
+++ b/packages/ui-lib/.eslintrc.js
@@ -3,6 +3,9 @@
  * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
  */
 
+// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
+require('@your-org/eslint-config-bases/patch/modern-module-resolution');
+
 const {
   getDefaultIgnorePatterns,
 } = require('@your-org/eslint-config-bases/helpers');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2903,7 +2903,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-eslint/eslint-plugin@npm:3.10.4":
+"@graphql-eslint/eslint-plugin@npm:^3.10.4":
   version: 3.10.4
   resolution: "@graphql-eslint/eslint-plugin@npm:3.10.4"
   dependencies:
@@ -6707,7 +6707,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/jest-dom@npm:5.16.4":
+"@testing-library/jest-dom@npm:5.16.4, @testing-library/jest-dom@npm:^5.16.4":
   version: 5.16.4
   resolution: "@testing-library/jest-dom@npm:5.16.4"
   dependencies:
@@ -6724,7 +6724,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react-hooks@npm:8.0.1":
+"@testing-library/react-hooks@npm:8.0.1, @testing-library/react-hooks@npm:^8.0.1":
   version: 8.0.1
   resolution: "@testing-library/react-hooks@npm:8.0.1"
   dependencies:
@@ -6746,7 +6746,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:13.3.0":
+"@testing-library/react@npm:13.3.0, @testing-library/react@npm:^13.3.0":
   version: 13.3.0
   resolution: "@testing-library/react@npm:13.3.0"
   dependencies:
@@ -7564,7 +7564,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/eslint-plugin@npm:5.30.5, @typescript-eslint/eslint-plugin@npm:^5.12.1":
+"@typescript-eslint/eslint-plugin@npm:5.30.5, @typescript-eslint/eslint-plugin@npm:^5.12.1, @typescript-eslint/eslint-plugin@npm:^5.30.5":
   version: 5.30.5
   resolution: "@typescript-eslint/eslint-plugin@npm:5.30.5"
   dependencies:
@@ -7587,7 +7587,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:5.30.5, @typescript-eslint/parser@npm:^5.12.1, @typescript-eslint/parser@npm:^5.21.0":
+"@typescript-eslint/parser@npm:5.30.5, @typescript-eslint/parser@npm:^5.12.1, @typescript-eslint/parser@npm:^5.21.0, @typescript-eslint/parser@npm:^5.30.5":
   version: 5.30.5
   resolution: "@typescript-eslint/parser@npm:5.30.5"
   dependencies:
@@ -8181,34 +8181,35 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@your-org/eslint-config-bases@workspace:packages/eslint-config-bases"
   dependencies:
-    "@graphql-eslint/eslint-plugin": "npm:3.10.4"
-    "@testing-library/jest-dom": "npm:5.16.4"
-    "@testing-library/react": "npm:13.3.0"
-    "@testing-library/react-hooks": "npm:8.0.1"
+    "@graphql-eslint/eslint-plugin": "npm:^3.10.4"
+    "@rushstack/eslint-patch": "npm:^1.1.0"
+    "@testing-library/jest-dom": "npm:^5.16.4"
+    "@testing-library/react": "npm:^13.3.0"
+    "@testing-library/react-hooks": "npm:^8.0.1"
     "@types/jest": "npm:28.1.4"
     "@types/node": "npm:18.0.0"
     "@types/prettier": "npm:2.6.3"
     "@types/react": "npm:18.0.15"
     "@types/react-dom": "npm:18.0.6"
-    "@typescript-eslint/eslint-plugin": "npm:5.30.5"
-    "@typescript-eslint/parser": "npm:5.30.5"
+    "@typescript-eslint/eslint-plugin": "npm:^5.30.5"
+    "@typescript-eslint/parser": "npm:^5.30.5"
     eslint: "npm:8.19.0"
-    eslint-config-prettier: "npm:8.5.0"
-    eslint-import-resolver-typescript: "npm:3.2.5"
-    eslint-plugin-import: "npm:2.26.0"
-    eslint-plugin-jest: "npm:26.5.3"
-    eslint-plugin-jest-formatting: "npm:3.1.0"
-    eslint-plugin-jsx-a11y: "npm:6.6.0"
-    eslint-plugin-playwright: "npm:0.9.0"
-    eslint-plugin-prettier: "npm:4.2.1"
-    eslint-plugin-react: "npm:7.30.1"
-    eslint-plugin-react-hooks: "npm:4.6.0"
-    eslint-plugin-regexp: "npm:1.7.0"
-    eslint-plugin-sonarjs: "npm:0.13.0"
-    eslint-plugin-tailwindcss: "npm:3.6.0"
-    eslint-plugin-testing-library: "npm:5.5.1"
+    eslint-config-prettier: "npm:^8.5.0"
+    eslint-import-resolver-typescript: "npm:^3.2.5"
+    eslint-plugin-import: "npm:^2.26.0"
+    eslint-plugin-jest: "npm:^26.5.3"
+    eslint-plugin-jest-formatting: "npm:^3.1.0"
+    eslint-plugin-jsx-a11y: "npm:^6.6.0"
+    eslint-plugin-playwright: "npm:^0.9.0"
+    eslint-plugin-prettier: "npm:^4.2.1"
+    eslint-plugin-react: "npm:^7.30.1"
+    eslint-plugin-react-hooks: "npm:^4.6.0"
+    eslint-plugin-regexp: "npm:^1.7.0"
+    eslint-plugin-sonarjs: "npm:^0.13.0"
+    eslint-plugin-tailwindcss: "npm:^3.6.0"
+    eslint-plugin-testing-library: "npm:^5.5.1"
     graphql: "npm:16.5.0"
-    prettier: "npm:2.7.1"
+    prettier: "npm:^2.7.1"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     rimraf: "npm:3.0.2"
@@ -13390,7 +13391,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:8.5.0":
+"eslint-config-prettier@npm:8.5.0, eslint-config-prettier@npm:^8.5.0":
   version: 8.5.0
   resolution: "eslint-config-prettier@npm:8.5.0"
   peerDependencies:
@@ -13411,7 +13412,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:3.2.5":
+"eslint-import-resolver-typescript@npm:3.2.5, eslint-import-resolver-typescript@npm:^3.2.5":
   version: 3.2.5
   resolution: "eslint-import-resolver-typescript@npm:3.2.5"
   dependencies:
@@ -13503,7 +13504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest-formatting@npm:3.1.0":
+"eslint-plugin-jest-formatting@npm:3.1.0, eslint-plugin-jest-formatting@npm:^3.1.0":
   version: 3.1.0
   resolution: "eslint-plugin-jest-formatting@npm:3.1.0"
   peerDependencies:
@@ -13512,7 +13513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jest@npm:26.5.3, eslint-plugin-jest@npm:^26.1.1":
+"eslint-plugin-jest@npm:26.5.3, eslint-plugin-jest@npm:^26.1.1, eslint-plugin-jest@npm:^26.5.3":
   version: 26.5.3
   resolution: "eslint-plugin-jest@npm:26.5.3"
   dependencies:
@@ -13529,7 +13530,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsx-a11y@npm:6.6.0, eslint-plugin-jsx-a11y@npm:^6.5.1":
+"eslint-plugin-jsx-a11y@npm:6.6.0, eslint-plugin-jsx-a11y@npm:^6.5.1, eslint-plugin-jsx-a11y@npm:^6.6.0":
   version: 6.6.0
   resolution: "eslint-plugin-jsx-a11y@npm:6.6.0"
   dependencies:
@@ -13568,7 +13569,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-playwright@npm:0.9.0":
+"eslint-plugin-playwright@npm:^0.9.0":
   version: 0.9.0
   resolution: "eslint-plugin-playwright@npm:0.9.0"
   peerDependencies:
@@ -13581,7 +13582,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:4.2.1":
+"eslint-plugin-prettier@npm:4.2.1, eslint-plugin-prettier@npm:^4.2.1":
   version: 4.2.1
   resolution: "eslint-plugin-prettier@npm:4.2.1"
   dependencies:
@@ -13596,7 +13597,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react-hooks@npm:4.6.0, eslint-plugin-react-hooks@npm:^4.3.0, eslint-plugin-react-hooks@npm:^4.5.0":
+"eslint-plugin-react-hooks@npm:4.6.0, eslint-plugin-react-hooks@npm:^4.3.0, eslint-plugin-react-hooks@npm:^4.5.0, eslint-plugin-react-hooks@npm:^4.6.0":
   version: 4.6.0
   resolution: "eslint-plugin-react-hooks@npm:4.6.0"
   peerDependencies:
@@ -13605,7 +13606,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-react@npm:7.30.1, eslint-plugin-react@npm:^7.28.0, eslint-plugin-react@npm:^7.29.4":
+"eslint-plugin-react@npm:7.30.1, eslint-plugin-react@npm:^7.28.0, eslint-plugin-react@npm:^7.29.4, eslint-plugin-react@npm:^7.30.1":
   version: 7.30.1
   resolution: "eslint-plugin-react@npm:7.30.1"
   dependencies:
@@ -13629,7 +13630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-regexp@npm:1.7.0":
+"eslint-plugin-regexp@npm:1.7.0, eslint-plugin-regexp@npm:^1.7.0":
   version: 1.7.0
   resolution: "eslint-plugin-regexp@npm:1.7.0"
   dependencies:
@@ -13647,7 +13648,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-sonarjs@npm:0.13.0":
+"eslint-plugin-sonarjs@npm:0.13.0, eslint-plugin-sonarjs@npm:^0.13.0":
   version: 0.13.0
   resolution: "eslint-plugin-sonarjs@npm:0.13.0"
   peerDependencies:
@@ -13656,7 +13657,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-tailwindcss@npm:3.6.0":
+"eslint-plugin-tailwindcss@npm:^3.6.0":
   version: 3.6.0
   resolution: "eslint-plugin-tailwindcss@npm:3.6.0"
   dependencies:
@@ -13667,7 +13668,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-testing-library@npm:5.5.1, eslint-plugin-testing-library@npm:^5.0.5":
+"eslint-plugin-testing-library@npm:5.5.1, eslint-plugin-testing-library@npm:^5.0.5, eslint-plugin-testing-library@npm:^5.5.1":
   version: 5.5.1
   resolution: "eslint-plugin-testing-library@npm:5.5.1"
   dependencies:
@@ -23242,7 +23243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prettier@npm:2.7.1":
+"prettier@npm:2.7.1, prettier@npm:^2.7.1":
   version: 2.7.1
   resolution: "prettier@npm:2.7.1"
   bin:


### PR DESCRIPTION
Expose [@rushstack/eslint-patch](https://www.npmjs.com/package/@rushstack/eslint-patch) through `@your-org/eslint-config-bases/patch/modern-module-resolution`.

## Purpose

By default workspaces consuming the [eslint-config-bases](https://github.com/belgattitude/nextjs-monorepo-example/tree/main/packages/eslint-config-bases) example *should* declare plugins as devDependencies. See [eslint limitation](https://github.com/eslint/eslint/issues/3458).

A workaround is to use the [@rushstack/eslint-patch](https://www.npmjs.com/package/@rushstack/eslint-patch).

> PS: Note the example wasn't impacted because it relies on
> [eslint-config-react-app](https://www.npmjs.com/package/eslint-config-react-app) which already comes with the rushstack patch

## Tasks

- [x] Add explicit dependency to `@rushstack/eslint-patch` 
- [x] Expose  `@your-org/eslint-config-bases/patch/modern-module-resolution');


## Recommended usage

Simply `require('@your-org/eslint-config-bases/patch/modern-module-resolution');` on top of workspace eslintrc.(js|cjs)

```js
/**
 * Specific eslint rules for this app/package, extends the base rules
 * @see https://github.com/belgattitude/nextjs-monorepo-example/blob/main/docs/about-linters.md
 */

// Workaround for https://github.com/eslint/eslint/issues/3458 (re-export of @rushstack/eslint-patch)
require('@your-org/eslint-config-bases/patch/modern-module-resolution');

const {
  getDefaultIgnorePatterns,
} = require('@your-org/eslint-config-bases/helpers');

module.exports = {
  root: true,
  parserOptions: {
    tsconfigRootDir: __dirname,
    project: 'tsconfig.json',
  },
  ignorePatterns: [...getDefaultIgnorePatterns(), '/storybook-static'],
  extends: [
    '@your-org/eslint-config-bases/typescript',
    '@your-org/eslint-config-bases/regexp',
    '@your-org/eslint-config-bases/sonar',
    '@your-org/eslint-config-bases/jest',
    '@your-org/eslint-config-bases/rtl',
    '@your-org/eslint-config-bases/storybook',
    '@your-org/eslint-config-bases/react',
    // Apply prettier and disable incompatible rules
    '@your-org/eslint-config-bases/prettier',
  ],
  rules: {
    // optional overrides per project
  },
  overrides: [
    // optional overrides per project file match
  ],
};

```

## Credits 

Thx to https://github.com/eslint/eslint/issues/3458#issuecomment-1179369396