### PR TITLE
ci: install with hardlinks-global (don't merge)

### DIFF
--- a/.github/actions/monorepo-install/action.yml
+++ b/.github/actions/monorepo-install/action.yml
@@ -40,6 +40,7 @@ runs:
       run: |
         yarn install --immutable --inline-builds
       env:
+        YARN_NM_MODE: 'hardlinks-global'
         PRISMA_SKIP_POSTINSTALL_GENERATE: ${{ inputs.skip-prisma-postinstall-generate }}
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: ${{ inputs.playwright-skip-browser-download }}
         HUSKY: 0


### PR DESCRIPTION
Based off yarn benchmark experiments: https://gist.github.com/belgattitude/0ecd26155b47e7be1be6163ecfbb0f0b.

## Tasks

- [x] Add YARN_NM_MODE='hardlinks-global' in install action
- [ ] Cache global storage (actions/cache)  

## Result

Need more tests. At first sight, on CI (cold start) it seems to be slower than hardlinks-local. 

Need to test this out with action/cache, but where is the global content addressable storage (?)

## Links

- Comment: https://gist.github.com/belgattitude/0ecd26155b47e7be1be6163ecfbb0f0b#benchyarn-lock-cache-nostate-hardinks-globalmd
- Linked possible improvements: https://github.com/yarnpkg/berry/pull/4533