### PR TITLE
Changesets: by default tag and version private workspaces

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,9 +1,10 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.1.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@2.2.0/schema.json",
   "changelog": [
     "@changesets/changelog-github",
     { "repo": "belgattitude/nextjs-monorepo-example" }
   ],
+  "privatePackages": { "version": true, "tag": true },
   "commit": true,
   "linked": [],
   "access": "restricted",

--- a/.changeset/polite-peas-type.md
+++ b/.changeset/polite-peas-type.md
@@ -1,0 +1,17 @@
+---
+"nextjs-app": patch
+"remix-app": patch
+"vite-app": patch
+"@your-org/api-gateway": patch
+"@your-org/common-i18n": patch
+"@your-org/core-lib": patch
+"@your-org/db-main-prisma": patch
+"@your-org/eslint-config-bases": patch
+"@your-org/ts-utils": patch
+"@your-org/ui-lib": patch
+---
+
+Changesets: by default will tag and version private packages
+
+Doc: https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md
+Ref: [changesets@2.25.0](https://github.com/changesets/changesets/releases/tag/%40changesets%2Fcli%402.25.0) & [#662](https://github.com/changesets/changesets/pull/662).


### PR DESCRIPTION
Changesets: by default will tag and version private packages

Doc: https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md
Ref: [changesets@2.25.0](https://github.com/changesets/changesets/releases/tag/%40changesets%2Fcli%402.25.0) & [#662](https://github.com/changesets/changesets/pull/662).
