### PR TITLE
ci: secure yarn install action

### DIFF
--- a/.github/actions/yarn-nm-install/action.yml
+++ b/.github/actions/yarn-nm-install/action.yml
@@ -25,29 +25,29 @@ runs:
   using: 'composite'
 
   steps:
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
+    - name: Expose yarn config as "$GITHUB_OUTPUT"
+      id: yarn-config
       shell: bash
-      run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+      run: |
+        echo "CACHE_FOLDER=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
 
-    # Yarn rotates the downloaded cache archives.
-    # @see https://github.com/actions/setup-node/issues/325
+    # Yarn rotates the downloaded cache archives, @see https://github.com/actions/setup-node/issues/325
+    # Yarn cache is also reusable between arch and os.
     - name: Restore yarn cache
       uses: actions/cache@v3
       id: yarn-download-cache
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
         key: yarn-download-cache-${{ hashFiles('yarn.lock') }}
         restore-keys: |
           yarn-download-cache-
 
-    # Invalidated on yarn.lock changes
+    # Save install_state (invalidated on yarn.lock changes)
     - name: Restore yarn install state
       id: yarn-install-state-cache
       uses: actions/cache@v3
       with:
-        path: |
-          .ci-cache/yarn-state
+        path: .yarn/ci-cache/
         key: ${{ runner.os }}-yarn-install-state-cache-${{ hashFiles('yarn.lock', '.yarnrc.yml') }}
 
     - name: Install dependencies
@@ -58,7 +58,7 @@ runs:
         # CI optimizations. Overrides yarnrc.yml options (or their defaults) in the CI action.
         YARN_ENABLE_GLOBAL_CACHE: 'false' # Use local cache folder to keep downloaded archives
         YARN_NM_MODE: 'hardlinks-local' # Hardlinks-(local|global) reduces io / node_modules size
-        YARN_INSTALL_STATE_PATH: .ci-cache/yarn-state/install-state.gz # Very small speedup when lock does not change
+        YARN_INSTALL_STATE_PATH: .yarn/ci-cache/install-state.gz # Very small speedup when lock does not change
         # Other environment variables
         HUSKY: '0' # By default do not run HUSKY install
         PRISMA_SKIP_POSTINSTALL_GENERATE: ${{ inputs.skip-prisma-postinstall-generate }}


### PR DESCRIPTION
Github actions have updated their policies


> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/