### PR TITLE
[Reproduction] PNPM filter does not work as stated in the doc

### DIFF
--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/pnpm-install
 
       - name: 👀 List changed packages
-        run: pnpm list -F "{packages}[origin/main]" --changed-files-ignore-pattern="**/*.md" -r --depth=-1 --json | jq --raw-output ".[].name"
+        run: pnpm list -F "{./packages/**}[origin/main]" --changed-files-ignore-pattern="**/*.md" --depth=-1 --json | jq --raw-output ".[].name"
 
       - name: Restore packages cache
         uses: actions/cache@v3
@@ -59,20 +59,20 @@ jobs:
 
       - name: Typecheck
         run: |
-          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" typecheck
+          pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" typecheck
 
       - name: Linter
         run: |
-          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint
-          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint-styles
+          pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint
+          pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint-styles
         env:
           TIMING: '1' # Allows to get output for eslint
 
       - name: Unit tests changed packages
-        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" test-unit
+        run: pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" test-unit
 
       - name: Run build for changed packages
-        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build
+        run: pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build
 
       - name: Run storybook build for changed packages
-        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build-storybook
+        run: pnpm -F "{./packages/**}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build-storybook

--- a/.github/workflows/ci-packages.yml
+++ b/.github/workflows/ci-packages.yml
@@ -44,7 +44,7 @@ jobs:
         uses: ./.github/actions/pnpm-install
 
       - name: 👀 List changed packages
-        run: pnpm list -F "{packages}[origin/main]" -r --depth=-1 --json | jq --raw-output ".[].name"
+        run: pnpm list -F "{packages}[origin/main]" --changed-files-ignore-pattern="**/*.md" -r --depth=-1 --json | jq --raw-output ".[].name"
 
       - name: Restore packages cache
         uses: actions/cache@v3
@@ -59,20 +59,20 @@ jobs:
 
       - name: Typecheck
         run: |
-          pnpm -F "{packages}[origin/main]" -r typecheck
+          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" typecheck
 
       - name: Linter
         run: |
-          pnpm -F "{packages}[origin/main]" -r lint
-          pnpm -F "{packages}[origin/main]" -r lint-styles
+          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint
+          pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" lint-styles
         env:
           TIMING: '1' # Allows to get output for eslint
 
       - name: Unit tests changed packages
-        run: pnpm -F "{packages}[origin/main]" -r test-unit
+        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" test-unit
 
       - name: Run build for changed packages
-        run: pnpm -F "{packages}[origin/main]" -r build
+        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build
 
       - name: Run storybook build for changed packages
-        run: pnpm -F "{packages}[origin/main]" -r build-storybook
+        run: pnpm -F "{packages}[origin/main]" -r --changed-files-ignore-pattern="**/*.md" build-storybook


### PR DESCRIPTION
> Tracked in https://github.com/pnpm/pnpm/issues/5497

Following the [pnpm docs about filtering](https://pnpm.io/filtering#--filter-glob---filter-glob), it's possible to combine `path/globs` and `since`. 

But when doing this:

```bash
pnpm list -F "{./packages/**}[origin/main]" -r --depth=-1 --json 
# ❌ does not return changed packages - nothing returned

pnpm -F "{./packages/**}[origin/main]" -r lint   
# ❌ ERR_PNPM_FILTER_CHANGED  Filtering by changed packages failed.
``` 

As a workaround thx to https://github.com/pnpm/pnpm/issues/4687#issuecomment-1235605016... it's possible to avoid using the glob:

```bash
pnpm list -F "{packages}[origin/main]" -r --depth=-1 --json | | jq --raw-output ".[].name"
# ✅ @your-org/api-gateway @your-org/db-main-prisma @your-org/eslint-config-bases @your-org/ts-utils
pnpm -F "{packages}[origin/main]" -r run eslint
# ✅ Correctly run the linter on changed packages
```
