### PR TITLE
Fix 3249

### DIFF
--- a/apps/remix-app/tsconfig.json
+++ b/apps/remix-app/tsconfig.json
@@ -29,7 +29,8 @@
       "@your-org/ui-lib/*": ["../../packages/ui-lib/src/*"],
       "@your-org/ui-lib": ["../../packages/ui-lib/src/index"],
       "@your-org/core-lib/*": ["../../packages/core-lib/src/*"],
-      "@your-org/core-lib": ["../../packages/core-lib/src/index"]
+      "@your-org/core-lib": ["../../packages/core-lib/src/index"],
+      "@your-org/ts-utils": ["../../packages/ts-utils/src/index"]
     }
     //"types": ["node", "jest", "@testing-library/jest-dom"]
   },

--- a/apps/vite-app/tsconfig.json
+++ b/apps/vite-app/tsconfig.json
@@ -13,7 +13,8 @@
       "@your-org/ui-lib/*": ["../../../packages/ui-lib/src/*"],
       "@your-org/ui-lib": ["../../../packages/ui-lib/src/index"],
       "@your-org/core-lib/*": ["../../../packages/core-lib/src/*"],
-      "@your-org/core-lib": ["../../../packages/core-lib/src/index"]
+      "@your-org/core-lib": ["../../../packages/core-lib/src/index"],
+      "@your-org/ts-utils": ["../../../packages/ts-utils/src/index"]
     }
   },
   "exclude": ["**/node_modules", "**/.*/", "dist"],

--- a/packages/ui-lib/package.json
+++ b/packages/ui-lib/package.json
@@ -19,9 +19,8 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "rimraf ./dist && cross-env NODE_ENV=production microbundle --tsconfig ./tsconfig.build.json --jsx React.createElement --jsxFragment React.Fragment -f cjs,es --no-compress",
-    "build-react17jsx": "microbundle --tsconfig ./tsconfig.build.json --jsx jsx --jsxImportSource react --globals react/jsx-runtime=jsx --compress",
-    "dev": "microbundle watch --tsconfig ./tsconfig.build.json",
+    "build": "tsup",
+    "dev": "tsup --watch",
     "clean": "rimraf ./dist ./build ./tsconfig.tsbuildinfo ./node_modules/.cache",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx,.cjs,.mjs --cache --cache-location ../../.cache/eslint/ui-lib.eslintcache",
     "typecheck": "tsc --project ./tsconfig.json --noEmit",
@@ -85,7 +84,6 @@
     "eslint": "8.33.0",
     "jest": "29.4.1",
     "jest-environment-jsdom": "29.4.1",
-    "microbundle": "0.15.1",
     "npm-run-all": "4.1.5",
     "postcss": "8.4.21",
     "postcss-flexbugs-fixes": "5.0.2",
@@ -100,6 +98,7 @@
     "tailwindcss": "3.2.4",
     "ts-jest": "29.0.5",
     "tsconfig-paths-webpack-plugin": "4.0.0",
+    "tsup": "6.5.0",
     "typescript": "4.9.5",
     "webpack": "5.75.0"
   }

--- a/packages/ui-lib/src/base/index.ts
+++ b/packages/ui-lib/src/base/index.ts
@@ -1,1 +1,2 @@
 export { Button } from './button/Button';
+export { BasicCard } from './card/BasicCard';

--- a/packages/ui-lib/tsconfig.build.json
+++ b/packages/ui-lib/tsconfig.build.json
@@ -2,12 +2,10 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src",
     "target": "esnext",
     "module": "esnext",
     "jsx": "react-jsx",
-    "jsxFactory": "",
-    "jsxFragmentFactory": ""
+    "incremental": false // dts with tsup requires rootDir if incremental (which does not work well aliases)
   },
   "exclude": ["**/*.stories.tsx", "**/*.stories.mdx", ".storybook/**"]
 }

--- a/packages/ui-lib/tsup.config.js
+++ b/packages/ui-lib/tsup.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig((options) => ({
+  entry: ['src/index.ts'],
+  splitting: true,
+  treeshake: true,
+  clean: true,
+  dts: true,
+  format: ['esm'],
+  platform: 'browser',
+  target: ['es2017', 'chrome70', 'edge18', 'firefox70', 'node14'],
+  tsconfig: new URL('./tsconfig.build.json', import.meta.url).pathname,
+  sourcemap: !options.watch,
+  minify: !options.watch,
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -9086,6 +9086,7 @@ __metadata:
     tailwindcss: "npm:3.2.4"
     ts-jest: "npm:29.0.5"
     tsconfig-paths-webpack-plugin: "npm:4.0.0"
+    tsup: "npm:6.5.0"
     typescript: "npm:4.9.5"
     webpack: "npm:5.75.0"
   peerDependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -9071,7 +9071,6 @@ __metadata:
     eslint: "npm:8.33.0"
     jest: "npm:29.4.1"
     jest-environment-jsdom: "npm:29.4.1"
-    microbundle: "npm:0.15.1"
     npm-run-all: "npm:4.1.5"
     postcss: "npm:8.4.21"
     postcss-flexbugs-fixes: "npm:5.0.2"


### PR DESCRIPTION
Provide a fix for https://github.com/belgattitude/nextjs-monorepo-example/issues/3249.

Quick explanation

- The ui package was initially built with microbundle
- Why ? cause it's easy and generally works with css as well...
- ... and it makes the build tree-shakable (code split) with no complex config
- But there's limitation: the rootDir must be the package src root (for dts to build)
- ... and that does not work well with typescript aliases (outside of src dir)
- There might be config tuning to do...
- ... But because it's an example, I just refactored to use tsup that allow to remove rootDir.
- It's not ideal because tsup has limitations too (like code splitting), example:

```
├── dist
│   ├── index.d.ts
│   ├── index.mjs
│   └── index.mjs.map
```

- In other words, rather than emitting multiple files, you'll have one. And that generally does not tree-shake in consuming apps.

Possible to tune. But in my experience the best is to use bare bone rollup config rather than tsup/microbundle... So we can adapt to what we do.

Out of scope for this project. 

At least it fixes the issue

 