### PR TITLE
Update zod move and set minimum to es2019+

### DIFF
--- a/apps/nextjs-app/.escheckrc
+++ b/apps/nextjs-app/.escheckrc
@@ -1,5 +1,5 @@
 {
-  "ecmaVersion": "es2018",
+  "ecmaVersion": "es2019",
   "module": false,
   "files": "./.next/static/chunks/**/*.js"
 }

--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -100,7 +100,7 @@
     "sharp": "0.31.3",
     "superjson": "1.12.2",
     "type-fest": "3.6.1",
-    "zod": "3.20.6"
+    "zod": "3.21.4"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "13.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -22138,7 +22138,7 @@ __metadata:
     vite-plugin-svgr: "npm:2.4.0"
     vite-tsconfig-paths: "npm:4.0.7"
     vitest: "npm:0.29.3"
-    zod: "npm:3.20.6"
+    zod: "npm:3.21.4"
   languageName: unknown
   linkType: soft
 
@@ -31013,10 +31013,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:3.20.6, zod@npm:^3.20.2":
+"zod@npm:3.20.6":
   version: 3.20.6
   resolution: "zod@npm:3.20.6"
   checksum: 27120c04343f4843cd1a5fe18b9505aaf4618d3583e23a30ee80bcba77cb75f8c0fd71565d783d3a79e199722a0f7a30372f6b622256f1e2a3ab403ebfb60164
+  languageName: node
+  linkType: hard
+
+"zod@npm:3.21.4, zod@npm:^3.20.2":
+  version: 3.21.4
+  resolution: "zod@npm:3.21.4"
+  checksum: f25f384f380c49d05a11541093a8d26f07688aa39f6a8adbd6dc338b43f63617bf138734fb1b79800ba374523f6a1bb561f7d401b3cc051fed2715eae5577d0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
See why 

- https://github.com/belgattitude/nextjs-monorepo-example/pull/3494