### PR TITLE
chore: supportedArchitectures set libc to current

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -28,5 +28,7 @@ supportedArchitectures:
     - current
   os:
     - current
+  libc:
+    - current
 
 yarnPath: .yarn/releases/yarn-4.0.0-rc.42.cjs


### PR DESCRIPTION
This allows to only install native binaries for the os/arch/libc(musl/glibc) at install time.

Why ? 

- slimmer docker install
- keep (vercel) lambdas size sane (vercel) 

See

- https://yarnpkg.com/configuration/yarnrc#supportedArchitectures

The config:

```yaml
supportedArchitectures:
  cpu:
    - current
  os:
    - current
  libc:
    - current
```

That helps with https://github.com/vercel/next.js/issues/42641

In the future npm/pnpm might support a similar config

- https://github.com/npm/rfcs/pull/519