### PR TITLE
TS use verbatimImport and small refactor of i18n types

### DIFF
--- a/apps/nextjs-app/package.json
+++ b/apps/nextjs-app/package.json
@@ -148,7 +148,6 @@
     "prettier": "2.8.8",
     "react-test-renderer": "18.2.0",
     "rimraf": "5.0.1",
-    "sass": "1.63.4",
     "size-limit": "8.2.4",
     "symlink-dir": "5.1.1",
     "sync-directory": "6.0.4",

--- a/apps/nextjs-app/postcss.config.cjs
+++ b/apps/nextjs-app/postcss.config.cjs
@@ -3,29 +3,16 @@
 // @link https://tailwindcss.com/docs/using-with-preprocessors
 
 const isProd = process.env.NODE_ENV === 'production';
-const supportsIE11 = false;
-const enableCssGrid = false;
 
 module.exports = {
   plugins: {
     tailwindcss: {},
     ...(isProd
       ? {
-          'postcss-flexbugs-fixes': {},
           'postcss-preset-env': {
-            autoprefixer: {
-              flexbox: 'no-2009',
-              // https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie
-              ...(enableCssGrid
-                ? {
-                    grid: 'autoplace',
-                  }
-                : {}),
-            },
+            // https://github.com/csstools/postcss-plugins/tree/main/plugin-packs/postcss-preset-env#stability-and-portability
             stage: 3,
-            features: {
-              'custom-properties': supportsIE11,
-            },
+            autoprefixer: { grid: true },
           },
         }
       : {}),

--- a/apps/nextjs-app/src/types.d/i18next.d.ts
+++ b/apps/nextjs-app/src/types.d/i18next.d.ts
@@ -4,12 +4,11 @@
  * you can opt out by commenting the following code.
  * @link https://react.i18next.com/latest/typescript
  */
-import 'react-i18next';
-import type { I18nNamespaces } from '@your-org/common-i18n';
+import type { I18nResources } from '@your-org/common-i18n';
 
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: 'common';
-    resources: I18nNamespaces;
+    resources: I18nResources;
   }
 }

--- a/apps/nextjs-app/tsconfig.jest.json
+++ b/apps/nextjs-app/tsconfig.jest.json
@@ -2,6 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "jsx": "react-jsx"
+    "target": "es2022",
+    "jsx": "react-jsx",
+    "isolatedModules": true, // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
+    "verbatimModuleSyntax": false // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
   }
 }

--- a/apps/remix-app/tsconfig.jest.json
+++ b/apps/remix-app/tsconfig.jest.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2022",
     "module": "commonjs",
     "moduleResolution": "node",
     "jsx": "react-jsx",
@@ -14,6 +14,7 @@
     "declaration": false,
     "noUnusedLocals": false,
     "noUnusedParameters": false,
-    "isolatedModules": true
+    "isolatedModules": true, // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
+    "verbatimModuleSyntax": false // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
   }
 }

--- a/apps/remix-app/tsconfig.json
+++ b/apps/remix-app/tsconfig.json
@@ -12,7 +12,6 @@
     "allowJs": true,
     "strict": true,
     "esModuleInterop": true,
-    "isolatedModules": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "noEmit": true,

--- a/packages/common-i18n/src/I18nResources.types.ts
+++ b/packages/common-i18n/src/I18nResources.types.ts
@@ -7,7 +7,7 @@ import type home from './locales/en/home.json';
 import type navigation from './locales/en/navigation.json';
 import type system from './locales/en/system.json';
 
-export interface I18nNamespaces {
+export interface I18nResources {
   admin: typeof admin;
   auth: typeof auth;
   blog: typeof blog;

--- a/packages/common-i18n/src/index.ts
+++ b/packages/common-i18n/src/index.ts
@@ -1,1 +1,1 @@
-export type { I18nNamespaces } from './I18nNamespaces';
+export type { I18nResources } from './I18nResources.types';

--- a/packages/core-lib/tsconfig.jest.json
+++ b/packages/core-lib/tsconfig.jest.json
@@ -2,16 +2,9 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "target": "es2022",
     "jsx": "react-jsx",
-    "noEmit": true,
-    "incremental": true,
-    "noImplicitAny": false,
-    "declaration": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "isolatedModules": true
+    "isolatedModules": true, // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
+    "verbatimModuleSyntax": false // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
   }
 }

--- a/packages/core-lib/tsconfig.json
+++ b/packages/core-lib/tsconfig.json
@@ -9,7 +9,6 @@
     "jsx": "react-jsx",
     "noEmit": false,
     "incremental": true,
-    "isolatedModules": true,
     "paths": {
       "@/test-utils": ["../config/test/test-utils"],
       "@your-org/ts-utils": ["../../../packages/ts-utils/src/index"]

--- a/packages/ts-utils/jest.config.js
+++ b/packages/ts-utils/jest.config.js
@@ -3,7 +3,7 @@ import { getTsconfig } from 'get-tsconfig';
 import { pathsToModuleNameMapper } from 'ts-jest';
 // import { getJestCachePath } from '../../cache.config';
 
-const tsConfigFile = new URL('./tsconfig.json', import.meta.url).pathname;
+const tsConfigFile = new URL('./tsconfig.jest.json', import.meta.url).pathname;
 
 /**
  * Transform the tsconfig paths into jest compatible one (support extends)

--- a/packages/ts-utils/tsconfig.jest.json
+++ b/packages/ts-utils/tsconfig.jest.json
@@ -1,15 +1,8 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "moduleResolution": "node",
-    "noEmit": true,
-    "incremental": true,
-    "noImplicitAny": false,
-    "declaration": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
+    "target": "es2022",
     "isolatedModules": true, // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
     "verbatimModuleSyntax": false // https://github.com/kulshekhar/ts-jest/issues/4081#issuecomment-1515758013
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,9 @@
 {
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "strict": true,
     "useUnknownInCatchVariables": true,
+    "verbatimModuleSyntax": true,
     "allowJs": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
@@ -9,7 +11,6 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
-    "isolatedModules": true,
     "incremental": true,
     "newLine": "lf"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9664,7 +9664,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:>=3.0.0 <4.0.0, chokidar@npm:^3.3.1, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
+"chokidar@npm:^3.3.1, chokidar@npm:^3.5.1, chokidar@npm:^3.5.3":
   version: 3.5.3
   resolution: "chokidar@npm:3.5.3"
   dependencies:
@@ -14034,13 +14034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^4.0.0":
-  version: 4.3.0
-  resolution: "immutable@npm:4.3.0"
-  checksum: 4fcd15a9b7d623e99cbb992f66ea1171218c1c0b2711dbe54a07588d1236c3fc768e47d75313799e9c6b4073bca70e973d57aba8b5c890bc6b22515b0da67e45
-  languageName: node
-  linkType: hard
-
 "immutable@npm:~3.7.6":
   version: 3.7.6
   resolution: "immutable@npm:3.7.6"
@@ -17771,7 +17764,6 @@ __metadata:
     react-test-renderer: "npm:18.2.0"
     rimraf: "npm:5.0.1"
     rooks: "npm:7.14.1"
-    sass: "npm:1.63.4"
     sharp: "npm:0.32.1"
     size-limit: "npm:8.2.4"
     superjson: "npm:1.12.3"
@@ -20979,19 +20971,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:1.63.4":
-  version: 1.63.4
-  resolution: "sass@npm:1.63.4"
-  dependencies:
-    chokidar: "npm:>=3.0.0 <4.0.0"
-    immutable: "npm:^4.0.0"
-    source-map-js: "npm:>=0.6.2 <2.0.0"
-  bin:
-    sass: sass.js
-  checksum: bd0602c9ef9e1b264fb2081a47ff925310415aa9f9a635e3afd04d29237446e108903d58461f2e8471150eedcc0bfff206abfd0b139590b01717e5f4ca471c2f
-  languageName: node
-  linkType: hard
-
 "saxes@npm:^6.0.0":
   version: 6.0.0
   resolution: "saxes@npm:6.0.0"
@@ -21523,7 +21502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:>=0.6.2 <2.0.0, source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2":
+"source-map-js@npm:^1.0.1, source-map-js@npm:^1.0.2":
   version: 1.0.2
   resolution: "source-map-js@npm:1.0.2"
   checksum: 4496d29f371909dbc27dfb302f31cadc70b6f1591b2b433337daf923fac30e9632523e169494b40d06b53228166a577875a3610bce3412de8bb600152f748a9c


### PR DESCRIPTION
- https://typescript-eslint.io/blog/consistent-type-imports-and-exports-why-and-how/
- https://devblogs.microsoft.com/typescript/announcing-typescript-5-0-beta/#verbatimmodulesyntax

and remove some unused / obsolete deps