### PR TITLE
fix(docker) nextjs unable to connect to db

### DIFF
--- a/apps/nextjs-app/.env
+++ b/apps/nextjs-app/.env
@@ -17,6 +17,8 @@ NEXT_BUILD_ENV_SOURCEMAPS=false
 # When deploying on serverless/lambdas "?connection_limit=" should be 1
 # @see https://www.prisma.io/docs/concepts/components/prisma-client/deployment#recommended-connection-limit
 PRISMA_DATABASE_URL=postgresql://nextjs:!ChangeMe!@localhost:5432/maindb?schema=public
+# for docker use the container name for the host
+#PRISMA_DATABASE_URL=postgresql://nextjs:!ChangeMe!@main-db:5432/maindb?schema=public
 
 # See https://github.com/soluble-io/cache-interop
 APP_CACHE_DSN=

--- a/docker/docker-compose.db.yml
+++ b/docker/docker-compose.db.yml
@@ -12,6 +12,8 @@ services:
       - POSTGRES_DB=maindb
       - POSTGRES_PASSWORD=!ChangeMe!
       - POSTGRES_USER=nextjs
+    networks:
+      - nextjs-monorepo-example-network
     volumes:
       - db_data:/var/lib/postgresql/data:rw
       # you may use a bind-mounted host directory instead,
@@ -20,3 +22,7 @@ services:
 
 volumes:
   db_data:
+
+networks:
+  nextjs-monorepo-example-network:
+    driver: bridge


### PR DESCRIPTION
To connect to the nextjs-monorepo-example-db container from the nextjs-app container both containers need to be in the same docker network. Otherwise, you get a connection error.

The service name main-db as the hostname when they are in the same network.